### PR TITLE
Update RootDialog.cs

### DIFF
--- a/Lab 2/Code Snippets/Lab 2.1/RootDialog.cs
+++ b/Lab 2/Code Snippets/Lab 2.1/RootDialog.cs
@@ -7,7 +7,6 @@ using Newtonsoft.Json.Linq;
 
 namespace Lab_2_1_Dialogs_Bot.Dialogs
 {
-{
     [Serializable]
     public class RootDialog : IDialog<object>
     {


### PR DESCRIPTION
Removed a second open curly brace at the top of the file that was causing an syntax error.